### PR TITLE
chore: add eks pod identity webhook chart

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish Helm Chart
+
+on:
+  repository_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.13.0
+      - name: Prepare chart
+        run: |
+          mkdir -p public
+          if git ls-remote --exit-code origin gh-pages; then
+            git fetch origin gh-pages
+            git show origin/gh-pages:index.yaml > public/index.yaml || true
+          fi
+          helm package charts/eks-pod-identity-webhook -d public
+          if [ -f public/index.yaml ]; then
+            helm repo index public --url "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}" --merge public/index.yaml
+          else
+            helm repo index public --url "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
+          fi
+      - name: Publish
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          publish_branch: gh-pages
+          keep_files: true

--- a/charts/eks-pod-identity-webhook/Chart.yaml
+++ b/charts/eks-pod-identity-webhook/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: eks-pod-identity-webhook
+description: Helm chart for deploying the EKS Pod Identity Webhook
+type: application
+version: 0.1.1
+appVersion: "0.1.1"

--- a/charts/eks-pod-identity-webhook/README.md
+++ b/charts/eks-pod-identity-webhook/README.md
@@ -1,0 +1,47 @@
+# EKS Pod Identity Webhook
+
+A Helm chart for deploying the EKS Pod Identity Webhook.
+
+## Installing the Chart
+
+Add the Mondu AI Helm repository:
+
+```bash
+helm repo add mondu-ai https://mondu-ai.github.io/eks-pod-identity-webhook
+helm repo update
+```
+
+Install or upgrade the chart:
+
+```bash
+helm upgrade --install eks-pod-identity-webhook \
+  mondu-ai/eks-pod-identity-webhook \
+  --namespace aws-pod-identity-webhook
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the release:
+
+```bash
+helm uninstall eks-pod-identity-webhook --namespace aws-pod-identity-webhook
+```
+
+## Configuration
+
+The following table lists the most commonly used parameters of the chart. See
+`values.yaml` for the full list.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `replicaCount` | Number of webhook replicas | `3` |
+| `image.repository` | Container image repository | `ghcr.io/mondu-ai/eks-pod-identity-webhook` |
+| `image.tag` | Image tag | `latest` |
+| `serviceAccount.create` | Create a service account | `true` |
+| `serviceAccount.name` | Service account name | `aws-pod-identity-webhook-sa` |
+| `certManager.enabled` | Manage certificates with cert-manager | `true` |
+| `existingTLSSecret` | Use an existing TLS secret | `""` |
+| `service.port` | Webhook service port | `443` |
+| `env.AWS_REGION` | Default AWS region | `us-east-1` |
+
+

--- a/charts/eks-pod-identity-webhook/templates/_helpers.tpl
+++ b/charts/eks-pod-identity-webhook/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{- define "eks-pod-identity-webhook.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "eks-pod-identity-webhook.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s" (include "eks-pod-identity-webhook.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "eks-pod-identity-webhook.namespace" -}}
+{{- .Release.Namespace -}}
+{{- end -}}

--- a/charts/eks-pod-identity-webhook/templates/certificate.yaml
+++ b/charts/eks-pod-identity-webhook/templates/certificate.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.certManager.enabled (not .Values.existingTLSSecret) }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "eks-pod-identity-webhook.fullname" . }}-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
+spec:
+  secretName: {{ .Values.certManager.secretName }}
+  duration: {{ .Values.certManager.certificate.duration }}
+  renewBefore: {{ .Values.certManager.certificate.renewBefore }}
+  commonName: {{ include "eks-pod-identity-webhook.fullname" . }}-svc.{{ .Release.Namespace }}.svc
+  dnsNames:
+    - {{ include "eks-pod-identity-webhook.fullname" . }}-svc.{{ .Release.Namespace }}.svc.cluster.local
+    - {{ include "eks-pod-identity-webhook.fullname" . }}-svc.{{ .Release.Namespace }}.svc
+  issuerRef:
+    name: {{ .Values.certManager.issuerName }}
+    kind: Issuer
+  usages:
+    - server auth
+    - client auth
+{{- end }}

--- a/charts/eks-pod-identity-webhook/templates/clusterrole.yaml
+++ b/charts/eks-pod-identity-webhook/templates/clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "eks-pod-identity-webhook.fullname" . }}-cr
+  labels:
+    app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["list", "watch"]

--- a/charts/eks-pod-identity-webhook/templates/clusterrolebinding.yaml
+++ b/charts/eks-pod-identity-webhook/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "eks-pod-identity-webhook.fullname" . }}-crb
+  labels:
+    app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "eks-pod-identity-webhook.fullname" . }}-cr
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.serviceAccount.name }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/eks-pod-identity-webhook/templates/deployment.yaml
+++ b/charts/eks-pod-identity-webhook/templates/deployment.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "eks-pod-identity-webhook.fullname" . }}-deployment
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
+    app.kubernetes.io/instance: {{ include "eks-pod-identity-webhook.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
+      app.kubernetes.io/instance: {{ include "eks-pod-identity-webhook.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
+        app.kubernetes.io/instance: {{ include "eks-pod-identity-webhook.fullname" . }}
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      automountServiceAccountToken: true
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      containers:
+        - name: webhook
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--tls-cert-path=/etc/webhook/certs/tls.crt"
+            - "--tls-key-path=/etc/webhook/certs/tls.key"
+            - "--listen-addr=:8443"
+            - "--aws-region={{ .Values.env.AWS_REGION }}"
+          ports:
+            - name: webhook-https
+              containerPort: 8443
+              protocol: TCP
+          env:
+            - name: GIN_MODE
+              value: {{ .Values.env.GIN_MODE }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: webhook-tls-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: webhook-https
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: webhook-https
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        - name: webhook-tls-certs
+          secret:
+            secretName: {{ default .Values.certManager.secretName .Values.existingTLSSecret }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}

--- a/charts/eks-pod-identity-webhook/templates/issuer.yaml
+++ b/charts/eks-pod-identity-webhook/templates/issuer.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.certManager.enabled (not .Values.existingTLSSecret) }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.certManager.issuerName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/charts/eks-pod-identity-webhook/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/eks-pod-identity-webhook/templates/mutatingwebhookconfiguration.yaml
@@ -1,0 +1,33 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "eks-pod-identity-webhook.fullname" . }}-cfg
+  labels:
+    app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
+  annotations:
+    {{- if not .Values.existingTLSSecret }}
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "eks-pod-identity-webhook.fullname" . }}-tls
+    {{- end }}
+webhooks:
+  - name: aws-pod-identity-webhook.mondu.internal
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    failurePolicy: Fail
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace }}
+        name: {{ include "eks-pod-identity-webhook.fullname" . }}-svc
+        path: "/mutate"
+        port: 443
+    objectSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: NotIn
+          values: ["{{ include "eks-pod-identity-webhook.name" . }}"]
+    rules:
+      - operations: ["CREATE", "UPDATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+        scope: "*"
+

--- a/charts/eks-pod-identity-webhook/templates/service.yaml
+++ b/charts/eks-pod-identity-webhook/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "eks-pod-identity-webhook.fullname" . }}-svc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
+    app.kubernetes.io/instance: {{ include "eks-pod-identity-webhook.fullname" . }}
+spec:
+  selector:
+    app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
+    app.kubernetes.io/instance: {{ include "eks-pod-identity-webhook.fullname" . }}
+  ports:
+    - name: https
+      port: {{ .Values.service.port }}
+      targetPort: webhook-https
+      protocol: TCP

--- a/charts/eks-pod-identity-webhook/templates/serviceaccount.yaml
+++ b/charts/eks-pod-identity-webhook/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.serviceAccount.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "eks-pod-identity-webhook.name" . }}
+{{- end }}

--- a/charts/eks-pod-identity-webhook/values.yaml
+++ b/charts/eks-pod-identity-webhook/values.yaml
@@ -1,0 +1,41 @@
+replicaCount: 3
+
+image:
+  repository: ghcr.io/mondu-ai/eks-pod-identity-webhook
+  tag: latest
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  create: true
+  name: aws-pod-identity-webhook-sa
+
+
+certManager:
+  enabled: true
+  issuerName: aws-pod-identity-webhook-selfsigned-issuer
+  secretName: aws-pod-identity-webhook-tls-secret
+  certificate:
+    duration: 2160h
+    renewBefore: 360h
+
+existingTLSSecret: ""
+
+service:
+  port: 443
+
+nodeSelector:
+  kubernetes.io/arch: arm64
+
+affinity: {}
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+env:
+  AWS_REGION: us-east-1
+  GIN_MODE: release


### PR DESCRIPTION
## Summary
- include `eks-pod-identity-webhook` chart from mondu-ai
- publish chart to `gh-pages` on `repository_dispatch`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68431bb833708326853678e7c7c05fb7