### PR TITLE
Fix GH pages publishing on merge

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish Helm Chart
 
 on:
+  push:
+    branches:
+      - main
   repository_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- trigger GH Pages publishing when merging to main

## Testing
- `helm lint charts/eks-pod-identity-webhook` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843245efd2c8326b3b36c88bfa626e0