### PR TITLE
chore: generate static HTML page for Helm chart listings

### DIFF
--- a/.github/scripts/generate_static_html.py
+++ b/.github/scripts/generate_static_html.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+
+import yaml
+import os
+
+# Define file paths
+yaml_file_path = 'public/index.yaml'
+template_html_path = 'index.html'  # Assuming this script is run from the repository root
+output_html_path = 'public/index.html'
+placeholder_comment = '<!-- Chart list will be populated here by the build script -->'
+
+def generate_chart_html(data):
+    """Generates HTML list for charts from parsed YAML data."""
+    if not data or 'entries' not in data:
+        print("No 'entries' found in YAML data or data is empty.")
+        return "<p>No chart entries found in index.yaml.</p>"
+
+    entries = data['entries']
+    if not entries:
+        return "<p>No charts listed in 'entries'.</p>"
+
+    html_parts = ['<ul class="chart-list">']
+    for chart_name, versions in sorted(entries.items()):
+        html_parts.append(f'  <li><h2>{chart_name}</h2>')
+        if versions:
+            html_parts.append('    <ul>')
+            for version_details in sorted(versions, key=lambda x: x.get('version'), reverse=True):
+                version = version_details.get('version', 'N/A')
+                description = version_details.get('description', '')
+                appVersion = version_details.get('appVersion', '')
+
+                display_text = f"Version: {version}"
+                if appVersion:
+                    display_text += f" (App: {appVersion})"
+                if description:
+                    display_text += f" - <em>{description}</em>"
+                html_parts.append(f'      <li>{display_text}</li>')
+            html_parts.append('    </ul>')
+        else:
+            html_parts.append('    <p>No versions listed for this chart.</p>')
+        html_parts.append('  </li>')
+    html_parts.append('</ul>')
+    return '\n'.join(html_parts)
+
+def main():
+    print(f"Starting static HTML generation: {template_html_path} + {yaml_file_path} -> {output_html_path}")
+
+    # 1. Read index.yaml
+    try:
+        with open(yaml_file_path, 'r', encoding='utf-8') as f:
+            yaml_data = yaml.safe_load(f)
+    except FileNotFoundError:
+        print(f"Error: YAML file not found at {yaml_file_path}")
+        # Create a minimal public/index.html indicating the issue
+        try:
+            with open(template_html_path, 'r', encoding='utf-8') as tpl_f:
+                template_html = tpl_f.read()
+            error_message_html = "<p><strong>Error: Chart index (index.yaml) not found. Cannot display charts.</strong></p>"
+            output_html = template_html.replace(placeholder_comment, error_message_html)
+            os.makedirs(os.path.dirname(output_html_path), exist_ok=True)
+            with open(output_html_path, 'w', encoding='utf-8') as out_f:
+                out_f.write(output_html)
+            print(f"Wrote minimal HTML to {output_html_path} indicating missing YAML.")
+        except Exception as e_tpl:
+            print(f"Additionally, could not process template HTML: {e_tpl}")
+        return # Exit if YAML is missing
+    except yaml.YAMLError as e:
+        print(f"Error parsing YAML file: {e}")
+        # Similar error handling for YAML parse error
+        try:
+            with open(template_html_path, 'r', encoding='utf-8') as tpl_f:
+                template_html = tpl_f.read()
+            error_message_html = f"<p><strong>Error: Could not parse chart index (index.yaml). Details: {e}</strong></p>"
+            output_html = template_html.replace(placeholder_comment, error_message_html)
+            os.makedirs(os.path.dirname(output_html_path), exist_ok=True)
+            with open(output_html_path, 'w', encoding='utf-8') as out_f:
+                out_f.write(output_html)
+            print(f"Wrote minimal HTML to {output_html_path} indicating YAML parsing error.")
+        except Exception as e_tpl:
+            print(f"Additionally, could not process template HTML: {e_tpl}")
+        return # Exit on YAML parse error
+
+    # 2. Generate HTML for charts
+    print("Generating HTML content for charts...")
+    charts_html = generate_chart_html(yaml_data)
+
+    # 3. Read the template index.html
+    try:
+        with open(template_html_path, 'r', encoding='utf-8') as f:
+            template_html = f.read()
+    except FileNotFoundError:
+        print(f"Error: Template HTML file not found at {template_html_path}")
+        # If template is missing, we can't really proceed to create a useful public/index.html
+        # However, the script's primary job is to process index.yaml, so this is a critical error.
+        return
+
+    # 4. Inject generated HTML into the template
+    if placeholder_comment in template_html:
+        output_html = template_html.replace(placeholder_comment, charts_html)
+        print(f"Successfully injected chart HTML into template using placeholder.")
+    else:
+        # Fallback or error if placeholder is missing.
+        # For now, let's try to append to a known div if it exists, or just log an error.
+        container_div_end_tag = '</div>' # from <div id="chart-list-container">
+        container_div_full_tag = '<div id="chart-list-container">'
+
+        # Try to find the specific container
+        container_start_index = template_html.find(container_div_full_tag)
+        if container_start_index != -1:
+            # Find where this div ends
+            end_tag_index = template_html.find(container_div_end_tag, container_start_index + len(container_div_full_tag))
+            if end_tag_index != -1:
+                output_html = template_html[:end_tag_index] + charts_html + template_html[end_tag_index:]
+                print("Warning: Placeholder comment not found. Appended chart HTML inside the 'chart-list-container' div.")
+            else: # No end tag for the container div
+                output_html = template_html + charts_html # Append at the end as a last resort
+                print("Error: Placeholder comment not found and could not properly locate end of 'chart-list-container' div. Appended to end of file.")
+        else: # Container div itself not found
+            output_html = template_html + charts_html # Append at the end as a last resort
+            print(f"Error: Placeholder comment '{placeholder_comment}' not found in template. Appended chart HTML to the end of the template as a fallback.")
+
+
+    # 5. Write the output HTML
+    try:
+        os.makedirs(os.path.dirname(output_html_path), exist_ok=True) # Ensure 'public/' directory exists
+        with open(output_html_path, 'w', encoding='utf-8') as f:
+            f.write(output_html)
+        print(f"Successfully generated and wrote static HTML to {output_html_path}")
+    except IOError as e:
+        print(f"Error writing output HTML file: {e}")
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,12 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: v3.13.0
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install PyYAML
+        run: pip install PyYAML
       - name: Prepare chart
         run: |
           mkdir -p public
@@ -39,6 +45,8 @@ jobs:
           else
             helm repo index public --url "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
           fi
+      - name: Generate static HTML page
+        run: python .github/scripts/generate_static_html.py
       - name: Publish
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Helm Chart Repository</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        h1 { text-align: center; }
+        .chart-list { list-style-type: none; padding: 0; }
+        .chart-list h2 { margin-top: 20px; margin-bottom: 5px; }
+        .chart-list ul { list-style-type: none; padding-left: 20px; }
+        .chart-list li { margin-bottom: 5px; }
+    </style>
+</head>
+<body>
+    <h1>Helm Charts</h1>
+    <div id="chart-list-container">
+        <!-- Chart list will be populated here by the build script -->
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This commit implements static generation of the `index.html` page to display Helm chart listings. This approach is more SEO-friendly and robust than the previous client-side rendering attempt.

Key changes:
- Added `.github/scripts/generate_static_html.py`: A Python script that reads `public/index.yaml` (generated by Helm) and uses `index.html` as a template to create a static `public/index.html` containing the list of charts and their versions.
- Modified `index.html` to serve as a basic template for the generation script.
- Updated the `.github/workflows/publish.yml` GitHub Actions workflow:
    - Added steps to set up Python and install the PyYAML dependency.
    - Added a step to execute the `generate_static_html.py` script after `index.yaml` is generated and before the site is published.
- Reverted a previous commit that implemented client-side JavaScript rendering.

This ensures that the main chart listing page is static HTML, improving discoverability by search engines and accessibility.