### PR TITLE
chore: add artifacthub-repo.yml in chart

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,8 @@ jobs:
           else
             helm repo index public --url "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
           fi
+      - name: Copy artifacthub-repo.yml
+        run: cp artifacthub-repo.yml public/
       - name: Generate static HTML page
         run: python .github/scripts/generate_static_html.py
       - name: Publish


### PR DESCRIPTION
The artifacthub-repo.yml file was not being included in the published chart assets on the gh-pages branch.

This commit updates the .github/workflows/publish.yml workflow to explicitly copy the artifacthub-repo.yml file to the public directory before the chart assets are published. This ensures that Artifact Hub can correctly discover and list the chart.