### PR TITLE
chore: bump chart versions for Go 1.26 rebuild

### DIFF
--- a/charts/eks-pod-identity-webhook/Chart.yaml
+++ b/charts/eks-pod-identity-webhook/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: eks-pod-identity-webhook
 description: Helm chart for deploying the EKS Pod Identity Webhook
 type: application
-version: 0.3.0
-appVersion: "0.1.2"
+version: 0.3.1
+appVersion: "0.1.4"

--- a/charts/gar-credential-provider/Chart.yaml
+++ b/charts/gar-credential-provider/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gar-credential-provider
 description: Install GAR credential provider on Kubernetes nodes via DaemonSet
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.2.1
+appVersion: "0.2.1"


### PR DESCRIPTION
Bumps chart versions to match Go 1.26 rebuilds (CVE-2025-68121, crypto/tls session resumption bypass).

- eks-pod-identity-webhook: chart 0.3.0 → 0.3.1, appVersion 0.1.2 → 0.1.4
- gar-credential-provider: chart 0.2.0 → 0.2.1, appVersion 0.2.0 → 0.2.1

Image tags default to `latest`, so running deployments pick up rebuilt images on next rollout. This just syncs chart metadata.